### PR TITLE
Ignore bashrc when checking for empty

### DIFF
--- a/files/hooks/supervisord-pre.d/40_nodejs_passenger_setup
+++ b/files/hooks/supervisord-pre.d/40_nodejs_passenger_setup
@@ -2,7 +2,7 @@
 
 set -e
 
-EMPTY=$([ $(ls -a /var/www | wc -l) -eq 2 ] && echo 'true' || echo 'false')
+EMPTY=$([ $(ls -A /var/www | grep -v bashrc | wc -l) -eq 0 ] && echo 'true' || echo 'false')
 
 if [ $EMPTY == 'true' ]; then
     echo "No files found in /var/www, attempting to get lock"


### PR DESCRIPTION
There is a race condition when deploying the customer ssh image at the same time as the web service as they are both mounting the same volume (/var/www) and making changes to it.

This fix should allow the default app to be installed even when the customerssh image has created a bashrc file